### PR TITLE
Remove secondary control details from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,6 @@ under their GPL-compatible licences.
 29. Resonant Feedback Clip
 30. Dynamic Sag
 
-Sine Erosion adds a secondary Noise control that morphs its delay modulator
-from a sine oscillator to band-pass-filtered pink noise. Character controls
-the oscillator or filter centre frequency on a 0 Hz to 10 kHz nonlinear scale.
-
-Five other algorithms expose the same compact secondary slider when selected:
-Tape Hysteresis — Bias, Transformer Core — Air Gap, Downsample — Jitter,
-Bit Crusher — Dither, and Schmitt Hysteresis — Slew. They all share one
-automatable `Secondary` parameter; the on-screen label and factory value follow
-the selected algorithm.
-
 ## Build
 
 ```sh


### PR DESCRIPTION
## Что изменено

Удалены два технических абзаца о вторичном параметре и его назначениях в отдельных алгоритмах.

## Почему

Эти детали не были согласованы для публичного README и перегружали краткое описание плагина.

## Проверка

- изменён только README.md
- удалены ровно указанные 10 строк
- проверка форматирования diff прошла без ошибок
